### PR TITLE
Send chore tracking date as ISO string.

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -86,7 +86,7 @@ customElements.whenDefined('card-tools').then(() => {
     _track(choreId){
       this._hass.callService("grocy", "execute_chore", {
         chore_id: choreId,
-        tracked_time: new Date(),
+        tracked_time: new Date().toISOString(),
         done_by: this.userId
       });
     }


### PR DESCRIPTION
Fixes the card to send requests to grocy.execute_chore using the ISO string format for the date and time, which that service requires per https://github.com/custom-components/grocy/blob/develop/custom_components/grocy/services.yaml .