### PR TITLE
Introduce helper method for string translations via card configuration

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -40,13 +40,22 @@ customElements.whenDefined('card-tools').then(() => {
 
     formatDueDate(dueDate, dueInDays) {
       if (dueInDays < 0)
-        return this.config.custom_translation != null && this.config.custom_translation.overdue != null ? this.config.custom_translation.overdue : "Overdue";
+        return this.translate("Overdue");
       else if (dueInDays == 0)
-        return this.config.custom_translation != null && this.config.custom_translation.today != null ? this.config.custom_translation.today : "Today";
+        return this.translate("Today");
       else
         return dueDate.substr(0, 10);
     }
 
+    translate(string) {
+      if((this.config.custom_translation != null) &&
+          (this.config.custom_translation[string] != null))
+          {
+             return this.config.custom_translation[string];
+          }
+      return string;
+    }
+  
     render(){
       return cardTools.LitHtml
       `
@@ -66,23 +75,31 @@ customElements.whenDefined('card-tools').then(() => {
                   <div>
                     ${chore._name}
                     <div class="secondary">
-                    ${this.config.custom_translation != null && this.config.custom_translation.due != null ? this.config.custom_translation.due : "Due"}: <span class="${chore._next_estimated_execution_time != null ? this.checkDueClass(chore.dueInDays) : ""}">${chore._next_estimated_execution_time != null ? this.formatDueDate(chore._next_estimated_execution_time, chore.dueInDays) : "-"}</span>
+                      ${this.translate("Due")}: <span class="${chore._next_estimated_execution_time != null ? this.checkDueClass(chore.dueInDays) : ""}">${chore._next_estimated_execution_time != null ? this.formatDueDate(chore._next_estimated_execution_time, chore.dueInDays) : "-"}</span>
                     </div>
-                    <div class="secondary">${this.config.custom_translation != null && this.config.custom_translation.last_tracked != null ? this.config.custom_translation.last_tracked : "Last tracked"}: ${chore._last_tracked_time != null ? chore._last_tracked_time.substr(0, 10) : "-"} </div>
+                    <div class="secondary">
+                      ${this.translate("Last tracked")}: ${chore._last_tracked_time != null ? chore._last_tracked_time.substr(0, 10) : "-"} ${
+                        chore._last_done_by._display_name != null ? this.translate("by") + " " + chore._last_done_by._display_name : ""
+                      }
+                    </div>
                   </div>
                   <div>
-                    <mwc-button @click=${ev => this._track(chore._chore_id)}>${this.config.custom_translation != null && this.config.custom_translation.track != null ? this.config.custom_translation.track : "Track"}</mwc-button>
+                    <mwc-button @click=${ev => this._track(chore._chore_id)}>${this.translate("Track")}</mwc-button>
                   </div>
-                </div>
-
-                `
-              )}` : cardTools.LitHtml`<div class="info flex">${this.config.custom_translation != null && this.config.custom_translation.empty != null ? this.config.custom_translation.empty : "No chores!"}</div>`}
+                </div>`
+              )}` : cardTools.LitHtml`<div class="info flex">${this.translate("No chores")}!</div>`}
             </div>
-            ${this.notShowing.length > 0 ? cardTools.LitHtml`<div class="secondary">${this.config.custom_translation != null && this.config.custom_translation.more != null ? this.config.custom_translation.more.replace("{number}", this.notShowing.length) : "Look in Grocy for " + this.notShowing.length + " more chores..."}</div>`
+            ${this.notShowing.length > 0 ? cardTools.LitHtml
+              `
+              <div class="secondary">
+                  ${this.translate("Look in Grocy for {number} more chores").replace("{number}", this.notShowing.length)}
+              </div>
+              `
             : ""}
           </ha-card>`}
       `;
-    }    
+    } 
+
     _track(choreId){
       this._hass.callService("grocy", "execute_chore", {
         chore_id: choreId,
@@ -194,9 +211,7 @@ customElements.whenDefined('card-tools').then(() => {
       this.requestUpdate();
     }
     
-
-  
-      // @TODO: This requires more intelligent logic
+    // @TODO: This requires more intelligent logic
     getCardSize() {
       return 3;
     }

--- a/info.md
+++ b/info.md
@@ -29,19 +29,21 @@ views:
 | show_quantity | number | **Optional** | The number of chores you want to show in the card.
 | show_days | number | **Optional** | `7` to only show chores that's due within 7 days.
 | user_id | number | **Optional** | Id of the Grocy user performing the tasks. Default if not specified is `1`, which should be the admin user in Grocy.
+| custom_translation| string-list | **optional** | List of translations of string values used in the card (see below).
 
 ## Advanced options
-I have added the possibility to translate the english in the card to whatever you like.
+It is possible to translate the following English strings in the card to whatever you like.
 
 ```yaml
 custom_translation:
-  overdue: "Försenad"
-  today: "Idag"
-  due: "Dags"
-  last_tracked: "Senast"
-  track: "Gör nu"
-  empty: "Tom"
-  more: "Det finns {number} fler göromål i Grocy"
+  Overdue: "Försenad"
+  Today: "Idag"
+  Due: "Dags"
+  'Last tracked': "Senast"
+  by: "av"
+  Track: "Gör nu"
+  'No chores': "Tom"
+  'Look in Grocy for {number} more chores': "Det finns {number} fler göromål i Grocy"
 ```
 
 


### PR DESCRIPTION
Hi!
I did some work on removing some of the translation-related boilerplate, by introducing a helper method that tries to find the string in the custom_translation list. 

There are a few functional changes that I hope you are willing to consider in this PR:

1) (will break existing configurations) The English string used in the config now has to match the one we would otherwise see in the card, if the translation wasn't there. 
For example: Previously `custom_translation.more' was used to indicate the translation string for `Look in Grocy for {number} more chores`. With this proposal, that attribute of `custom_translation` will also need to contain that full string in English. Luckily, yaml allows this. 
This is also the worst-case example, for the other strings (which are much shorter) it works quite naturally, and this approach just allows the original English string to fall through when it's not part of the translations.
I've tried to explain it in the example given in the info file.

2) (maintenance) Future strings (if any) also need to be matched in the configuration.

3) (minor) the last tracked date now also includes 'by <name>', because this is also part of the chore data.

Thank you for your consideration, I am eager to receive your feedback.

(This is my first contribution in JS, and the first with Swedish strings, please forgive any mistakes)