### PR TITLE
Add haptic feedback in-app usage & other minor affordances

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ views:
 | last_tracked_days_threshold  | number      | **Optional** | `0`      | Last tracked dates are reported as 'Today', 'Yesterday', 'x days ago' and finally the actual track date. This sets how many days use the 'x days ago' format, before it switches to using date notation.                             |
 | use_24_hours                 | bool        | **Optional** | `true`   | Sets if the times are shown in 12 hour or 24 hour formats.                                                                                                                                                                           |
 | hide_text_with_no_data       | bool        | **Optional** | `false`  | When true, if a property for an item is not set, it hides the text. For example, if a chore has never been completed, instead of showing 'Last tracked: -', it will hide the 'Last tracked' row entirely.                            |
+| haptic                       | string      | **Optional** | `selection` | Can be set to `light`, `success`, or anything [listed here](https://companion.home-assistant.io/docs/integrations/haptics/#developers-integrating-haptics-into-custom-cards).                                                     |
 
 ## Advanced options
 It is possible to translate the following English strings in the card to whatever you like.

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -193,7 +193,7 @@ class GrocyChoresCard extends LitElement {
 
     _renderItem(item) {
         return html`
-            <div class="${this.show_divider ? "grocy-item-container" : "grocy-item-container-no-border"} info flex">
+            <div class="${this.show_divider ? "grocy-item-container" : "grocy-item-container-no-border"} info flex" id="${item.__type}${item.id}">
                 <div>
                     ${this._renderItemName(item)}
                     ${this._shouldRenderDueInDays(item) ? this._renderDueInDays(item) : nothing}
@@ -520,6 +520,9 @@ class GrocyChoresCard extends LitElement {
     }
 
     _trackChore(choreId, choreName) {
+        // Hide the chore immediately, for better visual feedback
+        const x = this.shadowRoot.getElementById(`chore${choreId}`);
+        x.style.display = "none";
         this._hass.callService("grocy", "execute_chore", {
             chore_id: choreId, done_by: this.userId
         });
@@ -527,6 +530,9 @@ class GrocyChoresCard extends LitElement {
     }
 
     _trackTask(taskId, taskName) {
+        // Hide the task immediately, for better visual feedback
+        const x = this.shadowRoot.getElementById(`task${taskId}`);
+        x.style.display = "none";
         this._hass.callService("grocy", "complete_task", {
             task_id: taskId
         });

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -273,7 +273,7 @@ class GrocyChoresCard extends LitElement {
     _renderAddTaskButton() {
         return html`
             <mwc-button class="hide-button" @click=${() => this._toggleAddTask()}>
-                <ha-icon icon="mdi:chevron-down"></ha-icon>
+                <ha-icon icon="mdi:chevron-down" id="add-task-icon"></ha-icon>
                 ${this._translate("Add task")}
             </mwc-button>
         `
@@ -583,10 +583,13 @@ class GrocyChoresCard extends LitElement {
 
     _toggleAddTask() {
         const x = this.shadowRoot.getElementById("add-task-row");
+        const icon = this.shadowRoot.getElementById("add-task-icon");
         if (x.style.display === "none") {
             x.style.display = "flex";
+            icon.icon = "mdi:chevron-up";
         } else {
             x.style.display = "none";
+            icon.icon = "mdi:chevron-down";
         }
     }
 

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -547,6 +547,13 @@ class GrocyChoresCard extends LitElement {
                 message: `${this._translate(action)} "${itemName}".`, duration: 3000
             });
         }
+        this._fireHaptic();
+    }
+    
+    _fireHaptic() {
+        const myevent = new Event("haptic", {bubbles: true, composed: true, cancelable: false});
+        myevent.detail = "success";
+        window.dispatchEvent(myevent);
     }
 
     _toggleOverflow(documentFragment) {

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -557,9 +557,11 @@ class GrocyChoresCard extends LitElement {
     }
     
     _fireHaptic() {
-        const myevent = new Event("haptic", {bubbles: true, composed: true, cancelable: false});
-        myevent.detail = "success";
-        window.dispatchEvent(myevent);
+        if (this.haptic != null) {
+            const myevent = new Event("haptic", {bubbles: true, composed: true, cancelable: false});
+            myevent.detail = this.haptic;
+            window.dispatchEvent(myevent);
+        }
     }
 
     _toggleOverflow(documentFragment) {
@@ -652,6 +654,7 @@ class GrocyChoresCard extends LitElement {
         this.hide_text_with_no_data = this.config.hide_text_with_no_data ?? false;
         this.use_long_date = this.config.use_long_date ?? false;
         this.use_24_hours = this.config.use_24_hours ?? true;
+        this.haptic = this.config.haptic ?? "selection";
         this.task_icon = null
         this.chore_icon = null
         this.use_icons = this.config.use_icons ?? false;

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -193,7 +193,7 @@ class GrocyChoresCard extends LitElement {
 
     _renderItem(item) {
         return html`
-            <div class="${this.show_divider ? "grocy-item-container" : "grocy-item-container-no-border"} info flex" id="${item.__type}${item.id}">
+            <div class="${this.show_divider ? "grocy-item-container" : "grocy-item-container-no-border"} ${this.local_cached_hidden_items.includes(`${item.__type}${item.id}`) ? "hidden-class" : "show-class"} info flex" id="${item.__type}${item.id}">
                 <div>
                     ${this._renderItemName(item)}
                     ${this._shouldRenderDueInDays(item) ? this._renderDueInDays(item) : nothing}
@@ -520,9 +520,9 @@ class GrocyChoresCard extends LitElement {
     }
 
     _trackChore(choreId, choreName) {
-        // Hide the chore immediately, for better visual feedback
-        const x = this.shadowRoot.getElementById(`chore${choreId}`);
-        x.style.display = "none";
+        // Hide the chore on the next render, for better visual feedback
+        this.local_cached_hidden_items.push(`chore${choreId}`);
+        this.requestUpdate();
         this._hass.callService("grocy", "execute_chore", {
             chore_id: choreId, done_by: this.userId
         });
@@ -530,9 +530,9 @@ class GrocyChoresCard extends LitElement {
     }
 
     _trackTask(taskId, taskName) {
-        // Hide the task immediately, for better visual feedback
-        const x = this.shadowRoot.getElementById(`task${taskId}`);
-        x.style.display = "none";
+        // Hide the task on the next render, for better visual feedback
+        this.local_cached_hidden_items.push(`task${taskId}`);
+        this.requestUpdate();
         this._hass.callService("grocy", "complete_task", {
             task_id: taskId
         });
@@ -659,6 +659,12 @@ class GrocyChoresCard extends LitElement {
             this.task_icon = this.config.task_icon || 'mdi:checkbox-blank-outline';
             this.chore_icon = this.config.chore_icon || 'mdi:check-circle-outline';
         }
+    }
+
+
+    constructor() {
+        super();
+        this.local_cached_hidden_items = []
     }
 
     // @TODO: This requires more intelligent logic


### PR DESCRIPTION
I've successfully added and tested haptic feedback. Now, adding a task or tracking a task/chore gives a pleasant haptic on mobile.

I've also added code to immediately hide a task/chore when tracking it, so that the haptic, toast, and visual feedback are instantaneous. Because I only hide it until the next re-render updated from home assistant, this just gives a short-term affordance (for the first 1-3 seconds after interaction) but leaves the existing code path intact.

Lastly, I made the chevron for adding a task flip when the dialog is opened, which clarifies that tapping it again will close the dialog.