### PR TITLE
Rerender card when config changes

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -14,7 +14,7 @@ class GrocyChoresCard extends LitElement {
 
 
     _processItems() {
-        hass = this._hass;
+        let hass = this._hass;
         let allItems = [];
         this.entities = [];
         if(!hass) {

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -8,9 +8,18 @@ class GrocyChoresCard extends LitElement {
     }
 
     set hass(hass) {
-        let allItems = [];
         this._hass = hass;
+        this._processItems();
+    }
+
+
+    _processItems() {
+        hass = this._hass;
+        let allItems = [];
         this.entities = [];
+        if(!hass) {
+            return;
+        }
         if (Array.isArray(this.config.entity)) {
             for (let i = 0; i < this.config.entity.length; ++i) {
                 this.entities[i] = this.config.entity[i] in hass.states ? hass.states[this.config.entity[i]] : null;
@@ -105,6 +114,7 @@ class GrocyChoresCard extends LitElement {
             throw new Error('Please define entity');
         }
         this.config = config;
+        this._processItems();
     }
 
     render() {


### PR DESCRIPTION
Update the card when the config changes, this gives a better experience when editing the config, you can see the effect immediately in the preview window. 

#97 should ideally be merged before this, otherwise when typing an entity name, the preview window will crash while it is typing, since the intermediate entity name will not exist. 