### PR TITLE
Fix show_days default behavior

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -424,12 +424,15 @@ class GrocyChoresCard extends LitElement {
     _isItemVisible(item) {
         let visible = false;
         
-        visible = visible || (item.__due_in_days == null);
-        visible = visible && (item.__type === "chore" ? this.show_chores_without_due : true);
-        visible = visible && (item.__type === "task" ? this.show_tasks_without_due : true);
-
-        visible = visible || (item.__due_in_days < 0);
-        visible = visible || (item.__due_in_days <= this.show_days);
+        if(item.__due_in_days == null) {
+            visible = true;
+            visible = visible && (item.__type === "chore" ? this.show_chores_without_due : true);
+            visible = visible && (item.__type === "task" ? this.show_tasks_without_due : true);
+        } else {
+            visible = visible || this.show_days == null;
+            visible = visible || (item.__due_in_days < 0);
+            visible = visible || (item.__due_in_days <= this.show_days);
+        }
 
         visible = visible && (this.filter !== undefined ? this._checkMatchNameFilter(item) : true);
         visible = visible && (this.filter_user !== undefined ? this._checkMatchUserFilter(item) : true);


### PR DESCRIPTION
Fix #89 

When show_days is not defined, treat it as infinite.

I debated if this should override show_chores_without_due, but I decided to give show_chores_without_due a higher priority. Could have gone either way. 