### PR TITLE
Dynamic numeric string translation

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -148,7 +148,7 @@ class GrocyChoresCard extends LitElement {
                     <ha-button class="expand-button show-more-button"
                                @click=${() => this._toggleOverflow(this.renderRoot)}>
                         <div slot="icon" style="width: 100%;">
-                            <span class="mdc-button__label">${this._translate(`${this.overflow.length} More Items`)}</span>
+                            <span class="mdc-button__label">${this._translate("{number} More Items", this.overflow.length)}</span>
                         </div>
                         <div slot="trailingIcon">
                             <ha-icon slot="trailingIcon" style="--mdc-icon-size: ${this.expand_icon_size}px;"
@@ -217,7 +217,7 @@ class GrocyChoresCard extends LitElement {
     _renderNrItemsInGrocy() {
         return html`
             <div class="secondary not-showing">
-                ${this._translate(`Look in Grocy for ${this.itemsNotVisible} more items`)}
+                ${this._translate("Look in Grocy for {number} more items", this.itemsNotVisible)}
             </div>
         `
     }
@@ -366,7 +366,7 @@ class GrocyChoresCard extends LitElement {
         } else if (dueInDays < 2) {
             return this._translate("Tomorrow");
         } else if (dueInDays < this.due_in_days_threshold) {
-            return this._translate(`In ${dueInDays} days`);
+            return this._translate("In {number} days", dueInDays);
         } else {
             return this._formatDate(dueDate, true);
         }
@@ -378,17 +378,21 @@ class GrocyChoresCard extends LitElement {
         } else if (lastTrackedDays < 2) {
             return this._translate("Yesterday");
         } else if (lastTrackedDays < this.last_tracked_days_threshold) {
-            return this._translate(`${lastTrackedDays} days ago`);
+            return this._translate("{number} days ago", lastTrackedDays);
         } else {
             return this._formatDate(lastTrackedDate, dateOnly);
         }
     }
 
-    _translate(string) {
+    _translate(string, number) {
+        let newString = string;
         if ((this.config.custom_translation != null) && (this.config.custom_translation[string] != null)) {
-            return this.config.custom_translation[string];
+            newString = this.config.custom_translation[string];
         }
-        return string;
+        if(number != null) {
+            newString = newString.replace("{number}", number.toString());
+        }
+        return newString;
     }
 
     _taskDueDateInputFormat() {


### PR DESCRIPTION
Fix #92

A simple number replacement mechanism for translation strings. I didn't bother dealing with more complex cases than a single number, but that could be added in the future if necessary. Tried to keep with the syntax documented in the example. Works with 4 strings:

* "Look in Grocy for {number} more items"
* "{number} More Items"
* "In {number} days"
* "{number} days ago"

![image](https://user-images.githubusercontent.com/32912880/232170011-013502f8-be89-4638-893e-c934c043f825.png)

