### PR TITLE
Update getCardSize algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ views:
 | haptic                       | string      | **Optional** | `selection` | Can be set to `light`, `success`, or anything [listed here](https://companion.home-assistant.io/docs/integrations/haptics/#developers-integrating-haptics-into-custom-cards).                                                     |
 | show_description             | bool        | **Optional** | `false`  | When true, show the chore/task descriptions under the name. |
 | description_max_length       | number      | **Optional** |          | When set and `show_description` is set, truncate shown descriptions to the number of characters specified. |
-| fixed_tiling_size            | number      | **Optional** |          | When set, provides a fixed value to the masonry tiling algorithm for card size, where 1 unit equals 50 pixels. When unset, calculate the size dynamically from the number of items in the todo list. Setting the value will give a more consistent layout of masonry elements, though they may not be well balanced. When unset, the cards will be more compactly tiled for layout, but may move around on page refresh as as list length changes.
+| fixed_tiling_size            | number      | **Optional** |          | When set, provides a fixed value to the masonry tiling algorithm for card size, where 1 unit equals 50 pixels. When unset, calculate the size dynamically from the number of items in the todo list. Setting the value will give a more consistent layout of masonry elements, though they may not be well balanced. When unset, the cards will be more compactly tiled for layout, but may move around on page refresh as list length changes.
 
 ## Advanced options
 It is possible to translate the following English strings in the card to whatever you like.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ views:
 | haptic                       | string      | **Optional** | `selection` | Can be set to `light`, `success`, or anything [listed here](https://companion.home-assistant.io/docs/integrations/haptics/#developers-integrating-haptics-into-custom-cards).                                                     |
 | show_description             | bool        | **Optional** | `false`  | When true, show the chore/task descriptions under the name. |
 | description_max_length       | number      | **Optional** |          | When set and `show_description` is set, truncate shown descriptions to the number of characters specified. |
+| fixed_tiling_size            | number      | **Optional** |          | When set, provides a fixed value to the masonry tiling algorithm for card size, where 1 unit equals 50 pixels. When unset, calculate the size dynamically from the number of items in the todo list. Setting the value will give a more consistent layout of masonry elements, though they may not be well balanced. When unset, the cards will be more accurately tiled for layout, but may move around on page refresh as as list length changes.
 
 ## Advanced options
 It is possible to translate the following English strings in the card to whatever you like.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ views:
 | haptic                       | string      | **Optional** | `selection` | Can be set to `light`, `success`, or anything [listed here](https://companion.home-assistant.io/docs/integrations/haptics/#developers-integrating-haptics-into-custom-cards).                                                     |
 | show_description             | bool        | **Optional** | `false`  | When true, show the chore/task descriptions under the name. |
 | description_max_length       | number      | **Optional** |          | When set and `show_description` is set, truncate shown descriptions to the number of characters specified. |
-| fixed_tiling_size            | number      | **Optional** |          | When set, provides a fixed value to the masonry tiling algorithm for card size, where 1 unit equals 50 pixels. When unset, calculate the size dynamically from the number of items in the todo list. Setting the value will give a more consistent layout of masonry elements, though they may not be well balanced. When unset, the cards will be more accurately tiled for layout, but may move around on page refresh as as list length changes.
+| fixed_tiling_size            | number      | **Optional** |          | When set, provides a fixed value to the masonry tiling algorithm for card size, where 1 unit equals 50 pixels. When unset, calculate the size dynamically from the number of items in the todo list. Setting the value will give a more consistent layout of masonry elements, though they may not be well balanced. When unset, the cards will be more compactly tiled for layout, but may move around on page refresh as as list length changes.
 
 ## Advanced options
 It is possible to translate the following English strings in the card to whatever you like.

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -670,9 +670,15 @@ class GrocyChoresCard extends LitElement {
         this.local_cached_hidden_items = []
     }
 
-    // @TODO: This requires more intelligent logic
     getCardSize() {
-        return 3;
+        //an item seems to be about 70-80 pixels, depending on options, and a 'unit' of size is 50 pixels. 
+        if(Array.isArray(this.items)) {
+            let size = Math.floor(this.items.length * 3 / 2);
+            size = size < 3 ? 3 : size;
+            return size;
+        } else {
+            return 3;
+        }
     }
 }
 

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -741,8 +741,7 @@ class GrocyChoresCard extends LitElement {
         }
         //an item seems to be about 70-80 pixels, depending on options, and a 'unit' of size is 50 pixels. 
         if(Array.isArray(this.items)) {
-            let size = Math.floor(this.items.length * 3 / 2);
-            return size || 1;
+            return Math.floor(this.items.length * 3 / 2) || 1;
         } else {
             return 3;
         }

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -657,6 +657,7 @@ class GrocyChoresCard extends LitElement {
         this.haptic = this.config.haptic ?? "selection";
         this.task_icon = null
         this.chore_icon = null
+        this.fixed_tiling_size = this.config.fixed_tiling_size ?? null;
         this.use_icons = this.config.use_icons ?? false;
         if (this.use_icons) {
             this.task_icon = this.config.task_icon || 'mdi:checkbox-blank-outline';
@@ -671,11 +672,13 @@ class GrocyChoresCard extends LitElement {
     }
 
     getCardSize() {
+        if(this.fixed_tiling_size != null) {
+            return this.fixed_tiling_size;
+        }
         //an item seems to be about 70-80 pixels, depending on options, and a 'unit' of size is 50 pixels. 
         if(Array.isArray(this.items)) {
             let size = Math.floor(this.items.length * 3 / 2);
-            size = size < 3 ? 3 : size;
-            return size;
+            return size || 1;
         } else {
             return 3;
         }


### PR DESCRIPTION
The current getCardSize value of "3" is not great for larger todo lists. This value is used by the masonry layout engine to place cards on the dashboard, and 3 is a relatively small card size (1 unit of size is 50 pixels of height). This cause the layout engine to make some bad choices about where to place cards, it does not allocate them efficiently to columns, e,g.:

![image](https://user-images.githubusercontent.com/32912880/232901496-d0f1740b-7116-40c4-a093-28a6968d568c.png)

The circled cards would have been better allocated to the other two columns. 

By calculating the size based on the number of items, the layout engine can get a better idea of how to layout cards. This is the same cards with this PR applied:

![image](https://user-images.githubusercontent.com/32912880/232902212-0fbec9b5-89b3-49d4-9f2f-daefb7edcad1.png)

That said, I do recognize that there can be some drawback to this, in that while the layout is better packed, it may be less consistent as the number of items in the list change. Other cards in the panel may move around from time to time as the number of items in the list change, which I can imagine may be undesirable to some users. So I put in a configuration option to allow for assigning a fixed value. However I understand the description is a bit complex and wordy, not sure if there would be better way to phrase it. 
