### PR TITLE
Skip unnecessary reprocessing and rerender

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -7,9 +7,31 @@ class GrocyChoresCard extends LitElement {
         return style;
     }
 
+    _needUpdate(hass) {
+        const oldHass = this._hass;
+        if(oldHass == null) {
+            return true;
+        }
+        let entities = [].concat(this.config.entity);
+        for(let i=0; i<entities.length; i++) {
+            let e = entities[i];
+            if(e in hass.states) {
+                if(!e in oldHass.states) {
+                    return true;
+                }
+                if(hass.states[e] != oldHass.states[e]) {
+                    return true;
+                }
+            }
+        }
+    }
+
     set hass(hass) {
+        let update = this._needUpdate(hass);
         this._hass = hass;
-        this._processItems();
+        if(update) {
+            this._processItems();
+        }
     }
 
 
@@ -40,6 +62,7 @@ class GrocyChoresCard extends LitElement {
         this._configSetup();
 
         if (!Array.isArray(this.entities)) {
+            this.requestUpdate();
             return;
         }
 
@@ -66,6 +89,7 @@ class GrocyChoresCard extends LitElement {
         }
 
         if (allItems.length === 0) {
+            this.requestUpdate();
             return;
         }
 


### PR DESCRIPTION
Currently, the card reruns processItems, and reruns render() every time the `hass` object is updated. `hass` is updated for all cards every time _any_ entity in the entire home assistant instance changes any state or attribute. 

On a heavily used system, this could be happening once per second or more; and every time this happens we rerun through the entire processing stage, applying sort to all items, applying filters, comparing timestamps, etc. It's a lot of wasted processing.

This change skips further updating on a hass update unless one of the grocy entities tracked by the card actually changes. 

