### PR TITLE
Dynamic userid handling

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -511,7 +511,8 @@ class GrocyChoresCard extends LitElement {
     }
 
     _checkMatchUserFilter(item) {
-        return item.__user_id && item.__user_id === this.filter_user;
+        let user = this.filter_user === "current" ? this._getUserId() : this.filter_user;
+        return item.__user_id && item.__user_id === user;
     }
 
     _checkMatchTaskCategoryFilter(item) {
@@ -598,12 +599,20 @@ class GrocyChoresCard extends LitElement {
         return chores;
     }
 
+    _getUserId() {
+        if(typeof this.userId === "object") {
+            return this.userId[this._hass?.user?.name] ?? this.userId.default ?? 1;
+        } else {
+            return this.userId ?? 1;
+        }
+    }
+
     _trackChore(choreId, choreName) {
         // Hide the chore on the next render, for better visual feedback
         this.local_cached_hidden_items.push(`chore${choreId}`);
         this.requestUpdate();
         this._hass.callService("grocy", "execute_chore", {
-            chore_id: choreId, done_by: this.userId
+            chore_id: choreId, done_by: this._getUserId()
         });
         this._showTrackedToast(choreName);
     }
@@ -694,7 +703,7 @@ class GrocyChoresCard extends LitElement {
             taskData["due_date"] = taskDueDate;
         }
 
-        taskData["assigned_to_user_id"] = this.userId;
+        taskData["assigned_to_user_id"] = this._getUserId();
 
         this._hass.callService("grocy", "add_generic", {
             entity_type: "tasks", data: taskData


### PR DESCRIPTION
Allow using the current hass user for chore/task tracking, filtering. and creating new tasks.

To setup, in the config for user_id, setup a map from homeassistant usernames to grocy user_ids:

```
user_id:
  tim: 1
  bob: 2
  alice: 3
  default: 0
 ```
  
 Chores/Tasks will be tracked by the user_id that matches the username of the current logged in user. 
 
 If `filter_user` is set to the value "current", it will filter to the tasks/chores assigned to the current hass user. 

Still need to update the README for this behavior. I only really have one hass/grocy user, so this could probably use some extra testing, but it looked good in the debugger. 

Fix #45
Fix #95

Basically just eliminate the need for state switch. 