### PR TITLE
Add type date to the date input field

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -383,6 +383,7 @@ class GrocyChoresCard extends LitElement {
                 <paper-input
                         id="add-date"
                         class="add-input"
+                        type="date"
                         no-label-float
                         placeholder=${this._translate("Optional due date")}
                         value="${this._taskDueDateInputFormat()}">


### PR DESCRIPTION
This should fix #112 on all modern browsers (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date).

Validated to preserve the input formatting on Chrome 112