### PR TITLE
Pin lit to 2.8.0 to fix Babel errors with unpkg using lit version 3.x.x and above

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -1,4 +1,4 @@
-import {html, LitElement, nothing} from "https://unpkg.com/lit?module";
+import {html, LitElement, nothing} from "https://unpkg.com/lit@2.8.0?module";
 import {DateTime} from "https://unpkg.com/luxon@3.0.3?module";
 import style from './style.js';
 

--- a/style.js
+++ b/style.js
@@ -1,4 +1,4 @@
-import {css} from "https://unpkg.com/lit?module";
+import {css} from "https://unpkg.com/lit@2.8.0?module";
 
 const style = css`
 


### PR DESCRIPTION
`lit` version 3 was released a day ago, and today this card failed to load within my Home Assistant instance.

This seems to be due to experimental features not enabled on the Babel configuration for unpkg, resulting in errors that started appearing on unpkg links for `reactive-element` 2.0.0 and above (a dependency of `lit`): https://unpkg.com/@lit/reactive-element@2.0.0/reactive-element.js?module

For future reference, here's the error generated by unpkg:
```
Cannot generate module for @lit/reactive-element@2.0.0/reactive-element.js

SyntaxError: unknown: Support for the experimental syntax 'logicalAssignment' isn't currently enabled (6:629):

<clipped>
```

Pinning lit to 2.8.0 within both `js` files resolves the issue and allows the custom card to load.