### PR TITLE
Allow filtering on multiple users

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -564,8 +564,8 @@ class GrocyChoresCard extends LitElement {
     }
 
     _checkMatchUserFilter(item) {
-        let user = this.filter_user === "current" ? this._getUserId() : this.filter_user;
-        return item.__user_id === user;
+        let userArray = [].concat(this.filter_user).map((user) => user === "current" ? this._getUserId() : user);;
+        return userArray.some((user) => item.__user_id == user);
     }
 
     _checkMatchTaskCategoryFilter(item) {


### PR DESCRIPTION
Allow to specify a list to filter_user. 

Also fix a bug from #120,  setting filter_user to null was not matching unassigned tasks/chores as intended.