### PR TITLE
Add documentation URL to window object

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -858,6 +858,7 @@ window.customCards.push({
     name: 'Grocy Chores and Tasks Card',
     preview: false,
     description: 'A card used to display chores and/or tasks from the Grocy custom component.',
+    documentationURL: 'https://github.com/isabellaalstrom/lovelace-grocy-chores-card'
 });
 
 customElements.define('grocy-chores-card', GrocyChoresCard);


### PR DESCRIPTION
Add a documentation URL to the customCards window object. This is picked up by the frontend to generate a help link in the card editor which follows this link. 

