### PR TITLE
Clear Optional Due Date Input on Task Creation and Set Initial Due Date to Blank

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -783,6 +783,7 @@ class GrocyChoresCard extends LitElement {
         });
 
         this.shadowRoot.getElementById('add-task').value = "";
+        this.shadowRoot.getElementById('add-date').value = "";
 
         this._showAddedToast(taskName);
     }

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -501,8 +501,7 @@ class GrocyChoresCard extends LitElement {
     }
 
     _taskDueDateInputFormat() {
-        const now = DateTime.now();
-        return now.toFormat("yyyy-LL-dd");
+        return '';
     }
 
     _formatDate(dateTime, isDateOnly = false) {


### PR DESCRIPTION
Set the due date to be blank initially instead of today's date when creating a new task.

You also can't clear the due date if you were to select one during task creation. Was slightly annoying when you created a task with one and then wanted to create a task without one right after. Would have to back out of the app and then re-open.

