### PR TITLE
Fix adding tasks

### DIFF
--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -387,7 +387,7 @@ class GrocyChoresCard extends LitElement {
 
     _renderAddTask() {
         return html`
-            <div id="add-task-row" class="add-row">
+            <div id="add-task-row" class="add-row hidden-class">
                 <mwc-button @click=${() => this._addTask()}>
                     <ha-icon class="add-icon" icon="mdi:plus"></ha-icon>
                 </mwc-button>
@@ -744,14 +744,14 @@ class GrocyChoresCard extends LitElement {
     }
 
     _toggleAddTask() {
-        const x = this.shadowRoot.getElementById("add-task-row");
-        const icon = this.shadowRoot.getElementById("add-task-icon");
-        if (x.style.display === "none") {
-            x.style.display = "flex";
-            icon.icon = "mdi:chevron-up";
+        const addTaskRow = this.shadowRoot.getElementById("add-task-row");
+        const addTaskIcon = this.shadowRoot.getElementById("add-task-icon");
+        if (addTaskRow.classList.contains('hidden-class')) {
+            addTaskRow.classList.remove('hidden-class');
+            addTaskIcon.icon = "mdi:chevron-up";
         } else {
-            x.style.display = "none";
-            icon.icon = "mdi:chevron-down";
+            addTaskRow.classList.add('hidden-class');
+            addTaskIcon.icon = "mdi:chevron-down";
         }
     }
 

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -387,7 +387,7 @@ class GrocyChoresCard extends LitElement {
 
     _renderAddTask() {
         return html`
-            <div style="display: none;" id="add-task-row" class="add-row">
+            <div id="add-task-row" class="add-row">
                 <mwc-button @click=${() => this._addTask()}>
                     <ha-icon class="add-icon" icon="mdi:plus"></ha-icon>
                 </mwc-button>
@@ -400,8 +400,7 @@ class GrocyChoresCard extends LitElement {
                         id="add-date"
                         class="add-input"
                         .locale=${this._hass.locale}
-                        .label=${this._translate("Optional due date")}
-                        .value="${this._taskDueDateInputFormat()}">
+                        .label=${this._translate("Optional due date")}>
                 </ha-date-input>
             </div>
         `


### PR DESCRIPTION
Display was set to none which was either always broken or then it broke recently but the whole add-task-row was hidden.

Also removed the default value on the date-input, since the date is optional if you set it to something, you can't set it back to nothing.

(Image showing them displaying again, ignore the theme!)
![image](https://github.com/user-attachments/assets/a1af91b1-cb30-4fc7-82ad-d9ea49f0fb07)

This fixes #159 

Tested on Home Asisstant versions:
Core 2024.11.1
Frontend 20241106.2