### PR TITLE
Feat: date selector and skip buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ views:
 | show_last_tracked            | bool        | **Optional** | `true`   | Show when someone last tracked this chore (does not work on tasks).                                                                                                                                                                  |
 | show_last_tracked_by         | bool        | **Optional** | `true`   | Show who last tracked this chore (`show_last_tracked` must be true to show this) (does not work on tasks).                                                                                                                           |
 | show_track_button            | bool        | **Optional** | `true`   | Show track (complete) button                                                                                                                                                                                                         |
+| show_enable_reschedule        | bool        | **Optional** | `false`  | Show reschedule button for chores and tasks. When enabled, displays a "Reschedule" button (or `mdi:calendar-clock` icon if `use_icons` is true) to the left of the track button. Clicking it opens a dialog to select a new date and time (for chores) or date only (for tasks) for the item's next execution or due date. |
 | show_empty                   | bool        | **Optional** | `true`   | Set to false to hide card when no items                                                                                                                                                                                              |
 | show_create_task             | bool        | **Optional** | `false`  | Set to true to show ability to add a task in Grocy directly from the card. Due date must be in format yyyy-mm-dd, e.g. 2022-01-31. When due date is empty, task has no due date.                                                     |
 | browser_mod                  | bool        | **Optional** | `false`  | Set to true _if you have installed [browser_mod v2](https://github.com/thomasloven/hass-browser_mod)_ and want feedback when tracking or adding a task, in the form of a native toast bar.                                           |
@@ -85,6 +86,15 @@ custom_translation:
   'Last tracked': "Senast"
   by: "av"
   Track: "Gör nu"
+  Reschedule: "Förflytta"
+  'Reschedule Chore': "Förflytta göromål"
+  'Reschedule Task': "Förflytta uppgift"
+  Date: "Datum"
+  Time: "Tid"
+  Cancel: "Avbryt"
+  'Chore rescheduled': "Göromål förflyttat"
+  'Task rescheduled': "Uppgift förflyttat"
+  'Date is required': "Datum krävs"
   'No todos': "Tomt"
   'Look in Grocy for {number} more items': "Det finns {number} fler göromål i Grocy"
   'Add task': "Lägg till"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ views:
 | show_last_tracked_by         | bool        | **Optional** | `true`   | Show who last tracked this chore (`show_last_tracked` must be true to show this) (does not work on tasks).                                                                                                                           |
 | show_track_button            | bool        | **Optional** | `true`   | Show track (complete) button                                                                                                                                                                                                         |
 | show_enable_reschedule        | bool        | **Optional** | `false`  | Show reschedule button for chores and tasks. When enabled, displays a "Reschedule" button (or `mdi:calendar-clock` icon if `use_icons` is true) to the left of the track button. Clicking it opens a dialog to select a new date and time (for chores) or date only (for tasks) for the item's next execution or due date. |
+| show_skip_next          | bool        | **Optional** | `false`  | Show skip button for chores and tasks. When enabled, displays a "Skip" button (or `mdi:skip-next-circle-outline` icon if `use_icons` is true). For tasks, skips to the next day (next day after task's due date, or next day after today if task is in the past). For chores, marks the chore as skipped using the next estimated execution time. |
 | show_empty                   | bool        | **Optional** | `true`   | Set to false to hide card when no items                                                                                                                                                                                              |
 | show_create_task             | bool        | **Optional** | `false`  | Set to true to show ability to add a task in Grocy directly from the card. Due date must be in format yyyy-mm-dd, e.g. 2022-01-31. When due date is empty, task has no due date.                                                     |
 | browser_mod                  | bool        | **Optional** | `false`  | Set to true _if you have installed [browser_mod v2](https://github.com/thomasloven/hass-browser_mod)_ and want feedback when tracking or adding a task, in the form of a native toast bar.                                           |
@@ -95,6 +96,9 @@ custom_translation:
   'Chore rescheduled': "Göromål förflyttat"
   'Task rescheduled': "Uppgift förflyttat"
   'Date is required': "Datum krävs"
+  Skip: "Hoppa över"
+  'Chore skipped': "Göromål hoppat över"
+  'Task skipped': "Uppgift hoppat över"
   'No todos': "Tomt"
   'Look in Grocy for {number} more items': "Det finns {number} fler göromål i Grocy"
   'Add task': "Lägg till"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ views:
 | show_last_tracked            | bool        | **Optional** | `true`   | Show when someone last tracked this chore (does not work on tasks).                                                                                                                                                                  |
 | show_last_tracked_by         | bool        | **Optional** | `true`   | Show who last tracked this chore (`show_last_tracked` must be true to show this) (does not work on tasks).                                                                                                                           |
 | show_track_button            | bool        | **Optional** | `true`   | Show track (complete) button                                                                                                                                                                                                         |
-| show_enable_reschedule        | bool        | **Optional** | `false`  | Show reschedule button for chores and tasks. When enabled, displays a "Reschedule" button (or `mdi:calendar-clock` icon if `use_icons` is true) to the left of the track button. Clicking it opens a dialog to select a new date and time (for chores) or date only (for tasks) for the item's next execution or due date. |
+| show_enable_reschedule        | bool        | **Optional** | `false`  | Show reschedule button for chores and tasks. When enabled, displays a "Reschedule" button (or `mdi:calendar-clock` icon if `use_icons` is true) to the left of the track button. Clicking it opens a dialog with a "Skip to next day" button at the top (with `mdi:skip-next-circle-outline` icon), followed by a divider with "OR", and then date/time pickers. The "Skip to next day" button immediately reschedules the item to tomorrow using the current time (for chores) or just tomorrow's date (for tasks). Alternatively, you can select a custom date and time using the calendar picker. |
 | show_skip_next          | bool        | **Optional** | `false`  | Show skip button for chores and tasks. When enabled, displays a "Skip" button (or `mdi:skip-next-circle-outline` icon if `use_icons` is true). For tasks, skips to the next day (next day after task's due date, or next day after today if task is in the past). For chores, marks the chore as skipped using the next estimated execution time. |
 | show_empty                   | bool        | **Optional** | `true`   | Set to false to hide card when no items                                                                                                                                                                                              |
 | show_create_task             | bool        | **Optional** | `false`  | Set to true to show ability to add a task in Grocy directly from the card. Due date must be in format yyyy-mm-dd, e.g. 2022-01-31. When due date is empty, task has no due date.                                                     |
@@ -95,7 +95,11 @@ custom_translation:
   Cancel: "Avbryt"
   'Chore rescheduled': "Göromål förflyttat"
   'Task rescheduled': "Uppgift förflyttat"
+  'Chore rescheduled to next day': "Göromål förflyttat till nästa dag"
+  'Task rescheduled to next day': "Uppgift förflyttat till nästa dag"
   'Date is required': "Datum krävs"
+  'Skip to next day': "Hoppa till nästa dag"
+  OR: "ELLER"
   Skip: "Hoppa över"
   'Chore skipped': "Göromål hoppat över"
   'Task skipped': "Uppgift hoppat över"

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -691,6 +691,10 @@ class GrocyChoresCard extends LitElement {
             if (item.assigned_to_user) {
                 item.__user_id = item.assigned_to_user.id;
                 item.assigned_to_name = item.assigned_to_user.display_name;
+            } else if (item.assigned_to_user_id) {
+                // Handle case where assigned_to_user_id is provided directly
+                item.__user_id = item.assigned_to_user_id;
+                // Note: assigned_to_name will remain null/undefined in this case
             }
             
             if (item.due_date != null) {
@@ -944,10 +948,17 @@ class GrocyChoresCard extends LitElement {
                         </ha-time-input>
                     ` : nothing}
                 </div>
-                <mwc-button slot="primaryAction" @click=${() => this._doReschedule()}>
+                <mwc-button 
+                    slot="primaryAction" 
+                    @click=${() => this._doReschedule()}
+                    raised
+                    unelevated>
                     ${this._translate("Reschedule")}
                 </mwc-button>
-                <mwc-button slot="secondaryAction" @click=${() => this._closeRescheduleDialog()}>
+                <mwc-button 
+                    slot="secondaryAction" 
+                    @click=${() => this._closeRescheduleDialog()}
+                    outlined>
                     ${this._translate("Cancel")}
                 </mwc-button>
             </ha-dialog>
@@ -1052,6 +1063,10 @@ class GrocyChoresCard extends LitElement {
                 if (item.assigned_to_user) {
                     item.__user_id = item.assigned_to_user.id;
                     item.assigned_to_name = item.assigned_to_user.display_name;
+                } else if (item.assigned_to_user_id) {
+                    // Handle case where assigned_to_user_id is provided directly
+                    item.__user_id = item.assigned_to_user_id;
+                    // Note: assigned_to_name will remain null/undefined in this case
                 }
                 
                 if (item.due_date != null) {

--- a/grocy-chores-card.js
+++ b/grocy-chores-card.js
@@ -1060,14 +1060,13 @@ class GrocyChoresCard extends LitElement {
                 <div>
                     <!-- Skip to next day button -->
                     <div style="margin-bottom: 16px;">
-                        <mwc-button 
+                        <ha-button 
                             @click=${() => this._skipToNextDay()}
                             raised
-                            unelevated
                             style="width: 100%;">
                             <ha-icon icon="mdi:skip-next-circle-outline" style="margin-right: 8px;"></ha-icon>
                             ${this._translate("Skip to next day")}
-                        </mwc-button>
+                        </ha-button>
                     </div>
                     
                     <!-- Divider with OR -->

--- a/style.js
+++ b/style.js
@@ -121,6 +121,39 @@ const style = css`
     filter: drop-shadow(0 0 8px var(--primary, var(--primary-color, #03a9f4)));
   }
 
+  .skip-button {
+    --mdc-ripple-color: none;
+  }
+
+  .skip-button-icon {
+    color: var(--primary-text-color);
+    transition: color 0.3s ease, filter 0.3s ease;
+  }
+
+  .skip-button-icon:hover {
+    color: var(--primary, var(--primary-color, #03a9f4));
+    filter: drop-shadow(0 0 8px var(--primary, var(--primary-color, #03a9f4)));
+  }
+
+  .grocy-item-container .flex,
+  .grocy-item-container-no-border .flex {
+    align-items: center;
+  }
+
+  .action-buttons {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .reschedule-button,
+  .skip-button,
+  .track-button,
+  .track-checkbox {
+    flex-shrink: 0;
+  }
+
   .card-overflow-content {
 
   }

--- a/style.js
+++ b/style.js
@@ -107,6 +107,20 @@ const style = css`
     color: var(--green, var(--active-color, green));
   }
 
+  .reschedule-button {
+    --mdc-ripple-color: none;
+  }
+
+  .reschedule-button-icon {
+    color: var(--primary-text-color);
+    transition: color 0.3s ease, filter 0.3s ease;
+  }
+
+  .reschedule-button-icon:hover {
+    color: var(--primary, var(--primary-color, #03a9f4));
+    filter: drop-shadow(0 0 8px var(--primary, var(--primary-color, #03a9f4)));
+  }
+
   .card-overflow-content {
 
   }


### PR DESCRIPTION
I updated the readme for my filter change, but also added a reschedule option to select a date and time for chores, or date for tasks.  NOTE: For the reschedule popup, it will also show a skip to next day for easy selection OR allow you to pick a custom date.  I also added the ability to skip tasks or chores to go to the next time they are scheduled with a separate button. 

For tasks, since its not natively supported in grocy to skip, I made it so it will select the next date after the task was due OR if it was equal or older than today, make it the next day (tomorrow).

Here are some screenshots. I tested a few variations of this. This is backwards compatible. 

Reschedule hidden, but skip shown: 
<img width="778" height="661" alt="image" src="https://github.com/user-attachments/assets/f5ead7dd-614f-485a-b3a3-761dc1faa117" />

All settings on:
<img width="781" height="665" alt="image" src="https://github.com/user-attachments/assets/d07a11bf-e2ef-4384-8ba5-daf7de3b2beb" />

Reschedule shown, but skip hidden
<img width="777" height="663" alt="image" src="https://github.com/user-attachments/assets/1234c633-693d-4a80-80e0-d290548c227a" />

Only done shown:
<img width="777" height="665" alt="image" src="https://github.com/user-attachments/assets/6c083759-b0c7-425c-916e-4d9aba4114ed" />

no icons, and only words:
<img width="779" height="665" alt="image" src="https://github.com/user-attachments/assets/3c4a6f59-56cd-4cfa-8761-f413a8274417" />


chore date picker:
<img width="782" height="918" alt="image" src="https://github.com/user-attachments/assets/5f30794a-7b07-4b08-b6ab-9d4dc9a9be78" />



task date picker:
<img width="779" height="917" alt="image" src="https://github.com/user-attachments/assets/c111b89c-bc06-4f8c-8dae-7c02273c7d3e" />



